### PR TITLE
Fix match option, Cat does opposite of Seq order

### DIFF
--- a/src/common/sparse_memory.scala
+++ b/src/common/sparse_memory.scala
@@ -33,9 +33,9 @@ class SparseAsyncReadMem(val addrWidth : Int) extends Module {
 	// search for addresses
 	case class MatchOption(valid: Bool, idx: UInt)
 	def addrMatch(addr: UInt) = {
-		val vector = Cat(address.zip(address_valid).map{
-			case (a, v) => a === addr && v})
-		MatchOption(vector =/= 0.U, OHToUInt(vector))
+		val matches = VecInit(address.zip(address_valid).map{
+			case (a, v) => (a === addr && v).suggestName(s"pick_$addr")}).asUInt
+		MatchOption(matches =/= 0.U, OHToUInt(matches))
 	}
 
 	// read


### PR DESCRIPTION
A pretty gnarly pitfall in Chisel, `Cat` is defined in such a way that it matches Verilog semantics which makes it the opposite of what one would expect for Scala collections.

To expand on this a bit:
```scala
val likeVerilog = Cat(0xaa.U, 0xbb.U)
// likeVerilog === 0xaabb.U
val xs = Seq(0xaa.U, 0xbb.U)
// xs(0) === 0xaa.U
// xs(1) === 0xbb.U
val y = Cat(xs)
// y === 0xaabb.U
val z = VecInit(xs).asUInt
// z === 0xbbaa.U
```

The unintuitive part here is that we obviously expect low indices in collections to be the least significant part, but Cat follows Verilog semantics of leftmost being more significant. In contrast, Scala collections start with the leftmost element being index 0.